### PR TITLE
Fix clock #16 hands spinning *back* to zero in Safari/Firefox.

### DIFF
--- a/src/16.scss
+++ b/src/16.scss
@@ -56,8 +56,12 @@ body {
 }
 
 @keyframes zero {
-  from {
+  0% {
     transform: rotate(-96deg);
+  }
+
+  100% {
+    transform: rotate(-90deg);
   }
 }
 


### PR DESCRIPTION
The `@keyframes` `from` is being changed to `0%` in the **production build** and appears to require a corresponding `100%` to behave the same.